### PR TITLE
remove extraneous tooltip code

### DIFF
--- a/AdiBags_Hearthstones.lua
+++ b/AdiBags_Hearthstones.lua
@@ -8,7 +8,6 @@ local AdiBags = LibStub("AceAddon-3.0"):GetAddon("AdiBags")
 
 local L = addon.L
 local MatchIDs
-local Tooltip
 local Result = {}
 
 local function AddToSet(Set, List)
@@ -210,19 +209,6 @@ local function MatchIDs_Init(self)
 	return Result
  end
 
-local function Tooltip_Init()
-	local tip, leftside = CreateFrame("GameTooltip"), {}
-	for i = 1, 6 do
-		local Left, Right = tip:CreateFontString(), tip:CreateFontString()
-		Left:SetFontObject(GameFontNormal)
-		Right:SetFontObject(GameFontNormal)
-		tip:AddFontStrings(Left, Right)
-		leftside[i] = Left
-	end
-	tip.leftside = leftside
-	return tip
-end
-
 local setFilter = AdiBags:RegisterFilter("Hearthstones", 92, "ABEvent-1.0")
 setFilter.uiName = TUTORIAL_TITLE31
 setFilter.uiDesc = L["Items that hearth you to various places."]
@@ -257,18 +243,6 @@ function setFilter:Filter(slotData)
 	if MatchIDs[slotData.itemId] then
 		return TUTORIAL_TITLE31
 	end
-
-	Tooltip = Tooltip or Tooltip_Init()
-	Tooltip:SetOwner(UIParent,"ANCHOR_NONE")
-	Tooltip:ClearLines()
-
-	if slotData.bag == BANK_CONTAINER then
-		Tooltip:SetInventoryItem("player", BankButtonIDToInvSlotID(slotData.slot, nil))
-	else
-		Tooltip:SetBagItem(slotData.bag, slotData.slot)
-	end
-
-	Tooltip:Hide()
 end
 
 function setFilter:GetOptions()


### PR DESCRIPTION
Tooltip is never used and generates significant lag when opening bags as each non-matched item creates a frame. You can look at https://wowpedia.fandom.com/wiki/Category:API_namespaces/C_Item for a different option than tooltip scanning if you need to expand functionality in the future.

Plus, API is changing for Dragonflight release: https://wowpedia.fandom.com/wiki/Patch_10.0.2/API_changes